### PR TITLE
Change gradientColor prop from string to three item tuple of numbers

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -61,7 +61,7 @@ interface MarqueeProps {
    * Type: Array<number> of length 3
    * Default: [255, 255, 255]
    */
-  gradientColor?: string;
+  gradientColor?: [number, number, number];
   /**
    * The width of the gradient on either side
    * Type: string


### PR DESCRIPTION
This component fails to compile when used in projects with strict typescript checks currently because the `gradientColor` prop is declared to be a string when it's used as an array. This PR declares it to be a three-item tuple of numbers.