### PR TITLE
[Feature Request] Adding loop props

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ export default App;
 | `gradientColor` | `Array<number>` of length 3 | `[255, 255, 255]` | The rgb color of the gradient as an array of length 3    |
 | `gradientWidth` | `number or string`          | `200`             | The width of the gradient on either side                 |
 | `children`      | `ReactNode`                 | `null`            | The children rendered inside the marquee                 |
-| `loop`          | `number`                    | `0`               | The number of loops, 0 is equivalent to infinite                 |
+| `loop`          | `number`                    | `0`               | The number of loops, 0 is equivalent to infinite         |

--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ export default App;
 | `gradientColor` | `Array<number>` of length 3 | `[255, 255, 255]` | The rgb color of the gradient as an array of length 3    |
 | `gradientWidth` | `number or string`          | `200`             | The width of the gradient on either side                 |
 | `children`      | `ReactNode`                 | `null`            | The children rendered inside the marquee                 |
+| `loop`          | `number`                    | `0`               | The number of loops, 0 is equivalent to infinite                 |

--- a/src/components/Marquee.scss
+++ b/src/components/Marquee.scss
@@ -52,7 +52,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  animation: scroll var(--duration) linear var(--delay) var(--infinite);
+  animation: scroll var(--duration) linear var(--delay) var(--iteration-count);
   animation-play-state: var(--play);
   animation-delay: var(--delay);
   animation-direction: var(--direction);

--- a/src/components/Marquee.scss
+++ b/src/components/Marquee.scss
@@ -52,7 +52,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  animation: scroll var(--duration) linear var(--delay) infinite;
+  animation: scroll var(--duration) linear var(--delay) var(--infinite);
   animation-play-state: var(--play);
   animation-delay: var(--delay);
   animation-direction: var(--direction);

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -75,11 +75,11 @@ interface MarqueeProps {
    */
   children?: React.ReactNode;
   /**
-   * Whether the marquee is infinite loop
+   * The number of loops, 0 is equivalent to infinite
    * Type: boolean
-   * Default: true
+   * Default: 0
    */
-  infiniteLoop?: boolean;
+   loop?: number;
 }
 
 const Marquee: React.FC<MarqueeProps> = ({
@@ -95,7 +95,7 @@ const Marquee: React.FC<MarqueeProps> = ({
   gradientColor = [255, 255, 255],
   gradientWidth = 200,
   children,
-  infiniteLoop = true
+  loop = 0
 }) => {
   // React Hooks
   const [containerWidth, setContainerWidth] = useState(0);
@@ -167,7 +167,7 @@ const Marquee: React.FC<MarqueeProps> = ({
                 direction === "left" ? "normal" : "reverse",
               ["--duration" as string]: `${duration}s`,
               ["--delay" as string]: `${delay}s`,
-              ["--infinite" as string]: infiniteLoop ? "infinite" : "",
+              ["--iteration-count" as string]: !!loop ? `${loop}` : "infinite",
             }}
             className="marquee"
           >

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -74,6 +74,12 @@ interface MarqueeProps {
    * Default: null
    */
   children?: React.ReactNode;
+  /**
+   * Whether the marquee is infinite loop
+   * Type: boolean
+   * Default: true
+   */
+  infiniteLoop?: boolean;
 }
 
 const Marquee: React.FC<MarqueeProps> = ({
@@ -89,6 +95,7 @@ const Marquee: React.FC<MarqueeProps> = ({
   gradientColor = [255, 255, 255],
   gradientWidth = 200,
   children,
+  infiniteLoop = true
 }) => {
   // React Hooks
   const [containerWidth, setContainerWidth] = useState(0);
@@ -160,6 +167,7 @@ const Marquee: React.FC<MarqueeProps> = ({
                 direction === "left" ? "normal" : "reverse",
               ["--duration" as string]: `${duration}s`,
               ["--delay" as string]: `${delay}s`,
+              ["--infinite" as string]: infiniteLoop ? "infinite" : "",
             }}
             className="marquee"
           >


### PR DESCRIPTION
Adding `animation-iteration-count` css as `loop` props

feature description:
- when setting `loop=n`, it will loop n times
- when setting `loop=0`, it will infinite loop
- default value of `loop` is `0`