### PR TITLE
fix: add depedency array for useeffect

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -126,7 +126,7 @@ const Marquee: React.FC<MarqueeProps> = ({
     return () => {
       window.removeEventListener("resize", calculateWidth);
     };
-  });
+  }, []);
 
   useEffect(() => {
     setIsMounted(true);


### PR DESCRIPTION
Adds a missing dependency array on a useeffect that was causing it run on every rerender.

<img width="513" alt="Screenshot 2021-12-29 at 01 58 14" src="https://user-images.githubusercontent.com/2035554/147620212-17946141-31ec-4a45-9f48-3e330642b121.png">
