### PR TITLE
Add marquee events

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -75,13 +75,13 @@ interface MarqueeProps {
    */
   gradientWidth?: number | string;
   /**
-   * A callback for when the marquee finishes scrolling. Only calls if loop is non-zero.
+   * A callback for when the marquee finishes scrolling and stops. Only calls if loop is non-zero.
    * Type: Function
    * Default: null
    */
   onFinish?: () => void;
   /**
-   * A callback for when the marquee finishes a cycle. Does not call if loop is zero.
+   * A callback for when the marquee finishes a loop. Does not call if maximum loops are reached (use onFinish instead).
    * Type: Function
    * Default: null
    */

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -75,6 +75,18 @@ interface MarqueeProps {
    */
   gradientWidth?: number | string;
   /**
+   * A callback for when the marquee finishes scrolling. Only calls if loop is non-zero.
+   * Type: Function
+   * Default: null
+   */
+  onFinish?: () => void;
+  /**
+   * A callback for when the marquee finishes a cycle. Does not call if loop is zero.
+   * Type: Function
+   * Default: null
+   */
+  onCycleComplete?: () => void;
+  /**
    * The children rendered inside the marquee
    * Type: ReactNode
    * Default: null
@@ -95,6 +107,8 @@ const Marquee: React.FC<MarqueeProps> = ({
   gradient = true,
   gradientColor = [255, 255, 255],
   gradientWidth = 200,
+  onFinish,
+  onCycleComplete,
   children,
 }) => {
   // React Hooks
@@ -170,6 +184,8 @@ const Marquee: React.FC<MarqueeProps> = ({
               ["--iteration-count" as string]: !!loop ? `${loop}` : "infinite",
             }}
             className="marquee"
+            onAnimationIteration={onCycleComplete}
+            onAnimationEnd={onFinish}
           >
             {children}
           </div>


### PR DESCRIPTION
Adds two new optional props: onFinish and onCycleComplete.

onFinish: A callback for when the marquee finishes scrolling and stops. Only calls if loop is non-zero.
onCycleComplete: A callback for when the marquee finishes a loop. Does not call if maximum loops are reached (use onFinish instead).

Closes #24.