### PR TITLE
Add dependency array for useEffect

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -140,7 +140,7 @@ const Marquee: React.FC<MarqueeProps> = ({
     return () => {
       window.removeEventListener("resize", calculateWidth);
     };
-  });
+  }, []);
 
   useEffect(() => {
     setIsMounted(true);


### PR DESCRIPTION
We noticed that the marquee re-renders every frame and found this `useEffect` that did not have a dependency array. 

This should also close #32 