### PR TITLE
Improve useEffect by adding dependency array + remove unnecessary duration state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,8 @@
         "typescript": "^4.0.3"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": ">= 16.8.0 || 18.0.0",
+        "react-dom": ">= 16.8.0 || 18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,8 @@
         "typescript": "^4.0.3"
       },
       "peerDependencies": {
-        "react": ">= 16.8.0 || 18.0.0",
-        "react-dom": ">= 16.8.0 || 18.0.0"
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -112,35 +112,35 @@ const Marquee: React.FC<MarqueeProps> = ({
   children,
 }) => {
   // React Hooks
-  const [containerWidth, setContainerWidth] = useState(0);
-  const [marqueeWidth, setMarqueeWidth] = useState(0);
   const [duration, setDuration] = useState(0);
   const [isMounted, setIsMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const marqueeRef = useRef<HTMLDivElement>(null);
-
-  const calculateWidth = () => {
-    // Find width of container and width of marquee
-    if (marqueeRef.current && containerRef.current) {
-      setContainerWidth(containerRef.current.getBoundingClientRect().width);
-      setMarqueeWidth(marqueeRef.current.getBoundingClientRect().width);
-    }
-
-    if (marqueeWidth < containerWidth) {
-      setDuration(containerWidth / speed);
-    } else {
-      setDuration(marqueeWidth / speed);
-    }
-  };
-
+  
   useEffect(() => {
-    calculateWidth();
+    if (!isMounted) return
+
+    const calculateWidth = () => {
+      // Find width of container and width of marquee
+      if (!marqueeRef.current || !containerRef.current) return
+
+      const containerWidth = containerRef.current.getBoundingClientRect().width
+      const marqueeWidth = marqueeRef.current.getBoundingClientRect().width
+
+      if (marqueeWidth < containerWidth) {
+        setDuration(containerWidth / speed)
+      } else {
+        setDuration(marqueeWidth / speed)
+      }
+    }
+
+    calculateWidth()
     // Rerender on window resize
-    window.addEventListener("resize", calculateWidth);
+    window.addEventListener('resize', calculateWidth)
     return () => {
-      window.removeEventListener("resize", calculateWidth);
-    };
-  });
+      window.removeEventListener('resize', calculateWidth)
+    }
+  }, [speed, isMounted])
 
   useEffect(() => {
     setIsMounted(true);

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -112,35 +112,30 @@ const Marquee: React.FC<MarqueeProps> = ({
   children,
 }) => {
   // React Hooks
-  const [duration, setDuration] = useState(0);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [marqueeWidth, setMarqueeWidth] = useState(0);
   const [isMounted, setIsMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const marqueeRef = useRef<HTMLDivElement>(null);
-  
+
   useEffect(() => {
-    if (!isMounted) return
+    if (!isMounted) return;
 
     const calculateWidth = () => {
       // Find width of container and width of marquee
-      if (!marqueeRef.current || !containerRef.current) return
-
-      const containerWidth = containerRef.current.getBoundingClientRect().width
-      const marqueeWidth = marqueeRef.current.getBoundingClientRect().width
-
-      if (marqueeWidth < containerWidth) {
-        setDuration(containerWidth / speed)
-      } else {
-        setDuration(marqueeWidth / speed)
+      if (marqueeRef.current && containerRef.current) {
+        setContainerWidth(containerRef.current.getBoundingClientRect().width);
+        setMarqueeWidth(marqueeRef.current.getBoundingClientRect().width);
       }
-    }
+    };
 
-    calculateWidth()
+    calculateWidth();
     // Rerender on window resize
-    window.addEventListener('resize', calculateWidth)
+    window.addEventListener("resize", calculateWidth);
     return () => {
-      window.removeEventListener('resize', calculateWidth)
-    }
-  }, [speed, isMounted])
+      window.removeEventListener("resize", calculateWidth);
+    };
+  }, [isMounted]);
 
   useEffect(() => {
     setIsMounted(true);
@@ -148,6 +143,12 @@ const Marquee: React.FC<MarqueeProps> = ({
 
   // Gradient color in an unfinished rgba format
   const rgbaGradientColor = `rgba(${gradientColor[0]}, ${gradientColor[1]}, ${gradientColor[2]}`;
+
+  // Animation duration
+  const duration =
+    marqueeWidth < containerWidth
+      ? containerWidth / speed
+      : marqueeWidth / speed;
 
   return (
     <Fragment>


### PR DESCRIPTION
An empty dependency array means `calculateWidth` gets called on every render. That's no good because inside `calculateWidth` there are two `getBoundingClientRect` which are expensive for the browser.

I also remove the `duration` state and instead derive it from the `containerWidth` and `marqueeWidth` states.

On a local test of a big site I'm building, I'm getting much less `calculateWidth` calls.

Should also solve #32.