### PR TITLE
Recalculate Speed when children change

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -118,17 +118,16 @@ const Marquee: React.FC<MarqueeProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const marqueeRef = useRef<HTMLDivElement>(null);
 
+  const calculateWidth = () => {
+    // Find width of container and width of marquee
+    if (marqueeRef.current && containerRef.current) {
+      setContainerWidth(containerRef.current.getBoundingClientRect().width);
+      setMarqueeWidth(marqueeRef.current.getBoundingClientRect().width);
+    }
+  };
+
   useEffect(() => {
     if (!isMounted) return;
-
-    const calculateWidth = () => {
-      // Find width of container and width of marquee
-      if (marqueeRef.current && containerRef.current) {
-        setContainerWidth(containerRef.current.getBoundingClientRect().width);
-        setMarqueeWidth(marqueeRef.current.getBoundingClientRect().width);
-      }
-    };
-
     calculateWidth();
     // Rerender on window resize
     window.addEventListener("resize", calculateWidth);
@@ -136,6 +135,11 @@ const Marquee: React.FC<MarqueeProps> = ({
       window.removeEventListener("resize", calculateWidth);
     };
   }, [isMounted]);
+
+  // Recalculate width when children change
+  useEffect(() => {
+    calculateWidth();
+  }, [children]);
 
   useEffect(() => {
     setIsMounted(true);


### PR DESCRIPTION
I believe this fixes:
#9 
and 
#18 



calculate width was only calculated on first render, and so change in the width of the children (for example, if the number of items in an array that is mapped into the \<Marquee/> changes) caused the items to move far too fast or slow.

~~I believe this also may fix the issue where there is a large gap between the last item and the next repeat of the first item.~~
It does not fix this issue.

@justin-chu 