### PR TITLE
feat: Add onMount callback prop, runs after mount

### DIFF
--- a/__tests__/Marquee.test.js
+++ b/__tests__/Marquee.test.js
@@ -113,4 +113,26 @@ describe("Marquee", () => {
     );
     expect(component.props().gradientWidth).toBe(100);
   });
+
+  test("should have a callback if passed", () => {
+    const component = mount(
+      <Marquee onMount={() => {}}>
+        <div>testing</div>
+      </Marquee>
+    );
+    expect(typeof component.props().onMount).toBe("function");
+  });
+
+  test("should call its onMount callback after mounting if it exists and is a function", () => {
+    const arr = [];
+    const runAfterMounting = () => {
+      arr.push(1, 2, 3);
+    };
+    mount(
+      <Marquee onMount={runAfterMounting}>
+        <div>testing</div>
+      </Marquee>
+    );
+    expect(arr.length).toBe(3);
+  });
 });

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -107,6 +107,12 @@ type MarqueeProps = {
    */
   onCycleComplete?: () => void;
   /**
+   * @description: A callback function that is invoked once the marquee has finished mounting. It can be utilized to recalculate the page size, if necessary.
+   * @type {() => void}
+   * @default null
+   */
+  onMount?: () => void;
+  /**
    * @description The children rendered inside the marquee
    * @type {ReactNode}
    * @default null
@@ -131,6 +137,7 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
     gradientWidth = 200,
     onFinish,
     onCycleComplete,
+    onMount,
     children,
   },
   ref
@@ -198,6 +205,13 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
     setIsMounted(true);
   }, []);
 
+  // Runs th onMount callback, if it is a function, when Marquee is mounted.
+  useEffect(() => {
+    if (typeof onMount === "function") {
+      onMount();
+    }
+  }, []);
+
   // Animation duration
   const duration = useMemo(() => {
     if (autoFill) {
@@ -227,8 +241,8 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
         direction === "up"
           ? "rotate(-90deg)"
           : direction === "down"
-          ? "rotate(90deg)"
-          : "none",
+            ? "rotate(90deg)"
+            : "none",
     }),
     [style, play, pauseOnHover, pauseOnClick, direction]
   );
@@ -262,8 +276,8 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
         direction === "up"
           ? "rotate(90deg)"
           : direction === "down"
-          ? "rotate(-90deg)"
-          : "none",
+            ? "rotate(-90deg)"
+            : "none",
     }),
     [direction]
   );

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -205,7 +205,7 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
     setIsMounted(true);
   }, []);
 
-  // Runs th onMount callback, if it is a function, when Marquee is mounted.
+  // Runs the onMount callback, if it is a function, when Marquee is mounted.
   useEffect(() => {
     if (typeof onMount === "function") {
       onMount();


### PR DESCRIPTION
This addresses issue #65 as it should help with knowing when the Marquee has mounted, especially for Libraries which need to calculate size of DOM, when the size changes.
Added 2 tests for good measure.
Cheers,
-Tochi
