### PR TITLE
change class name to more specific one

### DIFF
--- a/src/components/Marquee.scss
+++ b/src/components/Marquee.scss
@@ -15,7 +15,7 @@
   }
 }
 
-.overlay {
+.overlay_marquee {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -62,6 +62,7 @@
     0% {
       transform: translateX(0%);
     }
+
     100% {
       transform: translateX(-100%);
     }

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -241,8 +241,8 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
         direction === "up"
           ? "rotate(-90deg)"
           : direction === "down"
-          ? "rotate(90deg)"
-          : "none",
+            ? "rotate(90deg)"
+            : "none",
     }),
     [style, play, pauseOnHover, pauseOnClick, direction]
   );
@@ -276,8 +276,8 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
         direction === "up"
           ? "rotate(90deg)"
           : direction === "down"
-          ? "rotate(-90deg)"
-          : "none",
+            ? "rotate(-90deg)"
+            : "none",
     }),
     [direction]
   );
@@ -310,7 +310,7 @@ const Marquee: FC<MarqueeProps> = forwardRef(function Marquee(
       style={containerStyle}
       className={"marquee-container " + className}
     >
-      {gradient && <div style={gradientStyle} className="overlay" />}
+      {gradient && <div style={gradientStyle} className="overlay_marquee" />}
       <div
         className="marquee"
         style={marqueeStyle}


### PR DESCRIPTION
Hey Justin! Nice to meet you! I'm Ramiro, an argentinian developer working on a project that uses react and ruby on rails. I'm using your library that's awesome, but I'm having a problem: other library uses a class called overlay and is in conflict with yours. Does exist the possibilty on change the name? Or something in mind?

I really appreciate your answer!

Thank you very much!

Ramiro