### PR TITLE
Fix: Allow interactions with elements under the gradient overlay

### DIFF
--- a/src/components/Marquee.scss
+++ b/src/components/Marquee.scss
@@ -32,6 +32,8 @@
     position: absolute;
     width: var(--gradient-width);
     z-index: 2;
+    pointer-events: none;
+    touch-action: none;
   }
 
   &::after {


### PR DESCRIPTION
Hi,

Thanks for creating react-fast-marquee, it's been really useful in my projects. I noticed a small issue when I have links around my logos - they can't be interacted with under the gradient overlay. I've been overriding the library class to add `pointer-events: none;` and `touch-action: none;` to the CSS which solves the problem. Thought this tweak could be useful for others too. 

Cheers!