### PR TITLE
fix: let gradient fade to 0.1 instead of transparent

### DIFF
--- a/src/components/Marquee.scss
+++ b/src/components/Marquee.scss
@@ -21,7 +21,7 @@
   height: 100%;
 
   @mixin gradient {
-    background: linear-gradient(to right, var(--gradient-color), transparent);
+    background: linear-gradient(to right, var(--gradient-color), rgb(255,255,255, 0.1));
   }
 
   &::before,


### PR DESCRIPTION
transparent makes it to go towards black on webkit. this is more like it.

closes https://github.com/justin-chu/react-fast-marquee/issues/90

Before:

![image](https://github.com/justin-chu/react-fast-marquee/assets/4662748/62954249-5d1a-43f0-a062-ce3140022ef7)

After:

![image](https://github.com/justin-chu/react-fast-marquee/assets/4662748/d0c12822-3995-4600-a3c1-5fda0e517d4c)
