### PR TITLE
feat: exporting type

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -15,7 +15,7 @@ import React, {
 } from "react";
 import "./Marquee.scss";
 
-type MarqueeProps = {
+export type MarqueeProps = {
   /**
    * @description Inline style for the container div
    * @type {CSSProperties}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
-import Marquee from "./components/Marquee";
+import Marquee, {type MarqueeProps} from "./components/Marquee";
+
 
 export default Marquee;
+export type {MarqueeProps}


### PR DESCRIPTION
I was working on a reusable component with Marquee and I had to make props of Marquee Also for this component plus other props.
Unfortunately, Marquee hasn't exported the type which makes me hard-code it (repeat it).
Also, I think it will solve #77 

Desired outcome
```tsx
import Marquee, {type MarqueeProps} from "react-fast-marquee";
```