### PR TITLE
put direction of container to "left to right"

### DIFF
--- a/src/components/Marquee.scss
+++ b/src/components/Marquee.scss
@@ -1,4 +1,5 @@
 .rfm-marquee-container {
+  direction:ltr;
   overflow-x: hidden;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
this fixes an issue with RTL documents (that makes the library irrelevant) by preventing the container to inherit the "rtl" behaviour.

you can easily reproduce the glitchiness by putting direction to "rtl", or not defining it (by thus-inheriting from above) and wrap the Marquess in a div with direction="rtl".